### PR TITLE
Add PHP 8.2 to the pipeline

### DIFF
--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [ "8.1" ]
+        php-version: [ "8.2" ]
 
     env:
       COMPOSER_VERSION: 2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [ "8.1" ]
+        php-version: [ "8.2" ]
 
     env:
       COMPOSER_VERSION: 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [ "7.4", "8.0", "8.1" ]
+        php-version: [ "7.4", "8.0", "8.1", "8.2" ]
 
     env:
       COMPOSER_VERSION: 2
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         neo4j-version: [ "4.2", "4.3", "4.4" ]
-        php-version: [ "7.4", "8.0", "8.1" ]
+        php-version: [ "7.4", "8.0", "8.1", "8.2" ]
 
     services:
       neo4j:


### PR DESCRIPTION
This pull request closes #80 and does the following:

* Add PHP 8.2 to unit and integration testing pipelines;
* Increase the PHP version from PHP 8.1 to PHP 8.2 to static analysis and linting.