### PR TITLE
Restore PHP 8.1 as the version for PHPStan and PHP-CS-Fixer

### DIFF
--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [ "8.2" ]
+        php-version: [ "8.1" ]
 
     env:
       COMPOSER_VERSION: 2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [ "8.2" ]
+        php-version: [ "8.1" ]
 
     env:
       COMPOSER_VERSION: 2


### PR DESCRIPTION
PHP 8.2 is not fully supported by these tools yet.