### PR TITLE
Make the Variable section in the Pattern optional

### DIFF
--- a/src/Patterns/Pattern.php
+++ b/src/Patterns/Pattern.php
@@ -36,16 +36,21 @@ use WikibaseSolutions\CypherDSL\Traits\PatternTraits\PatternTrait;
 interface Pattern extends QueryConvertible
 {
     /**
+     * Returns whether a variable has been set for this pattern.
+     */
+    public function hasVariableSet(): bool;
+
+    /**
      * Explicitly assign a named variable to this pattern.
      *
-     * @param string|Variable $variable
+     * @param null|string|Variable $variable
      *
      * @return $this
      */
     public function withVariable($variable): self;
 
     /**
-     * Returns the variable of this pattern. This function generates a variable if none has been set.
+     * Returns the variable of this pattern. This function generates a variable if none has been set. It will implicitly set the variable of the pattern as well.
      */
     public function getVariable(): Variable;
 }

--- a/src/Traits/PatternTraits/PatternTrait.php
+++ b/src/Traits/PatternTraits/PatternTrait.php
@@ -25,15 +25,23 @@ trait PatternTrait
     protected ?Variable $variable = null;
 
     /**
+     * Returns whether a variable has been set for this pattern.
+     */
+    public function hasVariableSet(): bool
+    {
+        return $this->variable !== null;
+    }
+
+    /**
      * Explicitly assign a named variable to this object.
      *
-     * @param string|Variable $variable
+     * @param null|string|Variable $variable
      *
      * @return $this
      */
     public function withVariable($variable): self
     {
-        $this->variable = self::toName($variable);
+        $this->variable = $variable === null ? null : self::toName($variable);
 
         return $this;
     }

--- a/tests/unit/Traits/PatternTraits/PatternTraitTest.php
+++ b/tests/unit/Traits/PatternTraits/PatternTraitTest.php
@@ -72,6 +72,25 @@ final class PatternTraitTest extends TestCase
         $this->stub->withVariable(new stdClass());
     }
 
+    public function testPatternNotSet(): void
+    {
+        $this->assertFalse($this->stub->hasVariableSet());
+    }
+
+    public function testPatternSet(): void
+    {
+        $this->stub->withVariable("hello");
+        $this->assertTrue($this->stub->hasVariableSet());
+    }
+
+    public function testPatternUnSet(): void
+    {
+        $this->stub->withVariable("hello");
+        $this->stub->withVariable(null);
+
+        $this->assertFalse($this->stub->hasVariableSet());
+    }
+
     /**
      * @doesNotPerformAssertions
      */


### PR DESCRIPTION
Right now, it is impossible to query whether a variable has been set on a pattern. If you call `getVariable` it will generate a variable at all times.

To maintain backwards compatibility, I have kept the functionality of `getVariable` the same and instead opted for an extra method `hasVariableSet` to understand whether the pattern is anonymous or not.

On top of that, I have made it, so you can unset a variable by calling the `withVariable` method with a null parameter.

Hope this works for you.

Kind regards,

Ghlen